### PR TITLE
GSK-319 added prepare dataset while calling SHAP

### DIFF
--- a/giskard/ml_worker/core/model_explanation.py
+++ b/giskard/ml_worker/core/model_explanation.py
@@ -11,22 +11,25 @@ from giskard.ml_worker.core.model import GiskardModel
 
 
 def explain(model: GiskardModel, dataset: GiskardDataset, input_data: Dict):
+    def prepare_df(df):
+        return model.prepare_dataframe(
+            GiskardDataset(
+                df=df,
+                target=dataset.target,
+                feature_types=dataset.feature_types,
+                column_types=dataset.column_types,
+            )
+        )
+
     df = model.prepare_dataframe(dataset)
     feature_names = list(df.columns)
 
     # Make sure column order is that column order is the same as in df
     input_data_df = pd.DataFrame([input_data])[df.columns]
-    input_df = model.prepare_dataframe(
-        GiskardDataset(
-            df=input_data_df,
-            target=dataset.target,
-            feature_types=dataset.feature_types,
-            column_types=dataset.column_types,
-        )
-    )
+    input_df = prepare_df(input_data_df)
 
     def predict_array(array):
-        return model.prediction_function(pd.DataFrame(array, columns=list(df.columns)))
+        return model.prediction_function(prepare_df(pd.DataFrame(array, columns=list(df.columns))))
 
     example = background_example(df, dataset.feature_types)
     kernel = shap.KernelExplainer(predict_array, example)


### PR DESCRIPTION
We were not calling prepare dataset which used to cast the dytpes of the dataset to the original dtypes which led to an error while calling shap