### PR TITLE
Bug/gsk 277 change default threshold for prediction drift chi square and earthmover

### DIFF
--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -457,10 +457,10 @@ class GiskardProject:
         if target is not None and target in df.columns:
             df = df.drop(target, axis=1)
         try:
-            prediction_function(df.head(1))
+            prediction_function(df.iloc[[0]])
         except Exception:
             raise ValueError("Invalid prediction_function input.\n"
-                             "Please make sure that prediction_function(df.head(1)) does not return an error "
+                             "Please make sure that prediction_function(df.iloc[[0]]) does not return an error "
                              "message before uploading in Giskard")
         try:
             prediction = prediction_function(df)

--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -457,10 +457,10 @@ class GiskardProject:
         if target is not None and target in df.columns:
             df = df.drop(target, axis=1)
         try:
-            prediction_function(df.iloc[[0]])
+            prediction_function(df.head(1))
         except Exception:
             raise ValueError("Invalid prediction_function input.\n"
-                             "Please make sure that prediction_function(df.iloc[[0]]) does not return an error "
+                             "Please make sure that prediction_function(df.head(1)) does not return an error "
                              "message before uploading in Giskard")
         try:
             prediction = prediction_function(df)

--- a/giskard/ml_worker/testing/drift_tests.py
+++ b/giskard/ml_worker/testing/drift_tests.py
@@ -546,7 +546,7 @@ class DriftTests(AbstractTestCollection):
         for the classification labels predictions for a given slice
 
         Example : The test is passed when the  Chi Square value of classification labels prediction
-        for females between reference and actual sets is below 0.2
+        for females between reference and actual sets is below 0.05
 
         Args:
             actual_slice(GiskardDataset):


### PR DESCRIPTION
the threshold value for chi square updated in the description of  prediction drift for chi sqaure