### PR TITLE
GSK-324 replaced np.array_equal with np.allclose to assert approximate values of two predictions

### DIFF
--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -471,7 +471,7 @@ class GiskardProject:
                 "message before uploading in Giskard"
             )
         min_num_rows = min(len(df), 5)
-        GiskardProject._validate_deterministic_model(df.head(min_num_rows),
+        GiskardProject._validate_deterministic_model(df.iloc[:min_num_rows],
                                                      prediction[:min_num_rows],
                                                      prediction_function)
         GiskardProject._validate_prediction_output(df, model_type, prediction)
@@ -553,7 +553,7 @@ class GiskardProject:
         Asserts if the model is deterministic by asserting previous and current prediction on same data
         """
         new_prediction = prediction_function(sample_df)
-        assert np.array_equal(prev_prediction, new_prediction), "Model is stochastic and not deterministic"
+        assert np.allclose(prev_prediction, new_prediction), "Model is stochastic and not deterministic"
 
     def __repr__(self) -> str:
         return f"GiskardProject(project_key='{self.project_key}')"

--- a/tests/test_project_uploads.py
+++ b/tests/test_project_uploads.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from giskard.client.project import GiskardProject
+
 data = np.array(["g", "e", "e", "k", "s"])
 
 
@@ -48,8 +49,11 @@ def _test_prediction_function(data):
     return np.random.rand(5, 1)
 
 
+prev_pred = _test_prediction_function(data)
+
+
 @pytest.mark.parametrize('data,prev_prediction,prediction_function', [
-    (pd.DataFrame(data), _test_prediction_function, _test_prediction_function)
+    (pd.DataFrame(data), prev_pred, _test_prediction_function)
 ])
 def test_validate_deterministic_model(data, prev_prediction, prediction_function):
     with pytest.raises(AssertionError):


### PR DESCRIPTION
Issue : Hugging face pytorch models like roberta were predicting  probabilities : 
1st time predicting the same data : [[0.20366013 0.4938253  0.3025146 ]] 
2nd time predicting the same data : [[0.20366018 0.4938253  0.30251452]]

which led to Error : Model is stochastic and not deterministic

Solution : Replaced np.equal with np.allclose to compare two prediction approximations instead of exact values 