### PR TITLE
GSK-325/task added warning about the type of feature declared

### DIFF
--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -512,6 +512,7 @@ class GiskardProject:
 
     @staticmethod
     def validate_columns_columntypes(df: pd.DataFrame, column_types, target) -> pd.DataFrame:
+
         if not set(column_types.keys()).issubset(set(df.columns)):
             missing_columns = set(column_types.keys()) - set(df.columns)
             raise ValueError(
@@ -525,6 +526,20 @@ class GiskardProject:
                 raise ValueError(
                     f"Invalid column_types parameter: Please declare the type for "
                     f"{missing_columns} columns"
+                )
+
+        nuniques=df.nunique()
+        nuniques_max=20
+        for column in df.columns:
+            if nuniques[column] <= nuniques_max and column_types[column] == 'numeric':
+                warnings.warn(
+                    f"Feature '{column}' is declared as 'numeric' but has {nuniques[column]} (<= nuniques_max={nuniques_max}) distinct values. Are "
+                    f"you sure it is not a 'category' feature?"
+                )
+            elif nuniques[column] > nuniques_max and column_types[column] == 'categorical':
+                warnings.warn(
+                    f"Feature '{column}' is declared as 'categorical' but has {nuniques[column]} (> nuniques_max={nuniques_max}) distinct values. Are "
+                    f"you sure it is not a 'numeric' feature?"
                 )
 
         pandas_inferred_column_types = df.dtypes.to_dict()


### PR DESCRIPTION
To verify (get the warning) go to the notebook https://github.com/Giskard-AI/examples/blob/main/Churn_Telco_Kaggle_with_pipeline.ipynb and edit this cell:
```python
# Declare the type of each column in the dataset(example: category, numeric, text)
column_types = {'gender': "category",
                'SeniorCitizen': "category", 
                'Partner': "category", 
                'Dependents': "category", 
                'tenure': "numeric",
                'PhoneService': "category", 
                'MultipleLines': "category", 
                'InternetService': "category", 
                'OnlineSecurity': "category",
                'OnlineBackup': "category", 
                'DeviceProtection': "category", 
                'TechSupport': "category", 
                'StreamingTV': "category",
                'StreamingMovies': "category", 
                'Contract': "category", 
                'PaperlessBilling': "category", 
                'PaymentMethod': "category",
                'MonthlyCharges': "numeric", 
                'TotalCharges': "numeric", 
                'Churn': "category"}

# feature_types is used to declare the features the model is trained on
feature_types = {i:column_types[i] for i in column_types if i!='Churn'}
```
by setting `'SeniorCitizen': "numeric"`, you should see a warning when you execute the cell containing `churn_analysis_with_tfs.upload_model_and_df(...)`