### PR TITLE
GSK-342/task Added the case where prediction is constant after perturbation

### DIFF
--- a/giskard/ml_worker/testing/stat_utils.py
+++ b/giskard/ml_worker/testing/stat_utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy.stats as stats
 
 def paired_t_test(population_1, population_2, alternative, critical_quantile):
@@ -14,7 +15,10 @@ def paired_t_test(population_1, population_2, alternative, critical_quantile):
     if alternative not in ["less", "greater"]:
         raise ValueError("Incorrect alternative hypothesis! It has to be one of the following: ['less', 'greater']")
 
-    stat, p_value = stats.ttest_rel(population_1, population_2, alternative=alternative)
+    if np.array_equal(population_1, population_2):
+        p_value = 1.
+    else:
+        stat, p_value = stats.ttest_rel(population_1, population_2, alternative=alternative)
 
     if p_value > critical_quantile:
         return False, p_value
@@ -36,8 +40,15 @@ def equivalence_t_test(population_1, population_2, window_size, critical_quantil
     population_2_up = population_2 + window_size/2.
     population_2_low = population_2 - window_size/2.
 
-    p_value_up = stats.ttest_rel(population_1, population_2_up, alternative="less")[1]
-    p_value_low = stats.ttest_rel(population_1, population_2_low, alternative="greater")[1]
+    if np.array_equal(population_1, population_2_up):
+        p_value_up = 0.
+    else:
+        p_value_up = stats.ttest_rel(population_1, population_2_up, alternative="less")[1]
+
+    if np.array_equal(population_1, population_2_low):
+        p_value_low = 0.
+    else:
+        p_value_low = stats.ttest_rel(population_1, population_2_low, alternative="greater")[1]
 
     test_up = p_value_up < critical_quantile
     test_low = p_value_low < critical_quantile
@@ -65,7 +76,10 @@ def paired_wilcoxon(population_1, population_2, alternative, critical_quantile):
         raise ValueError(
             "Incorrect alternative hypothesis! It has to be one of the following: ['less', 'greater']")
 
-    stat, p_value = stats.wilcoxon(population_1, population_2, alternative=alternative)
+    if np.array_equal(population_1, population_2):
+        p_value = 1.
+    else:
+        stat, p_value = stats.wilcoxon(population_1, population_2, alternative=alternative)
 
     if p_value > critical_quantile:
         return False, p_value
@@ -88,8 +102,15 @@ def equivalence_wilcoxon(population_1, population_2, window_size, critical_quant
     population_2_up = population_2 + window_size/2.
     population_2_low = population_2 - window_size/2.
 
-    p_value_up = stats.wilcoxon(population_1, population_2_up, alternative="less")[1]
-    p_value_low = stats.wilcoxon(population_1, population_2_low, alternative="greater")[1]
+    if np.array_equal(population_1, population_2_up):
+        p_value_up = 0.
+    else:
+        p_value_up = stats.wilcoxon(population_1, population_2_up, alternative="less")[1]
+
+    if np.array_equal(population_1, population_2_low):
+        p_value_low = 0.
+    else:
+        p_value_low = stats.wilcoxon(population_1, population_2_low, alternative="greater")[1]
 
     test_up = p_value_up < critical_quantile
     test_low = p_value_low < critical_quantile

--- a/giskard/ml_worker/testing/stat_utils.py
+++ b/giskard/ml_worker/testing/stat_utils.py
@@ -37,14 +37,10 @@ def equivalence_t_test(population_1, population_2, window_size, critical_quantil
     population_2_up = population_2 + window_size/2.
     population_2_low = population_2 - window_size/2.
 
-    if np.array_equal(population_1, population_2_up):
-        p_value_up = 0.
+    if np.array_equal(population_1, population_2):
+        p_value_low, p_value_up = 0., 0.
     else:
         p_value_up = stats.ttest_rel(population_1, population_2_up, alternative="less")[1]
-
-    if np.array_equal(population_1, population_2_low):
-        p_value_low = 0.
-    else:
         p_value_low = stats.ttest_rel(population_1, population_2_low, alternative="greater")[1]
 
     test_up = p_value_up < critical_quantile
@@ -96,14 +92,10 @@ def equivalence_wilcoxon(population_1, population_2, window_size, critical_quant
     population_2_up = population_2 + window_size/2.
     population_2_low = population_2 - window_size/2.
 
-    if np.array_equal(population_1, population_2_up):
-        p_value_up = 0.
+    if np.array_equal(population_1, population_2):
+        p_value_low, p_value_up = 0., 0.
     else:
         p_value_up = stats.wilcoxon(population_1, population_2_up, alternative="less")[1]
-
-    if np.array_equal(population_1, population_2_low):
-        p_value_low = 0.
-    else:
         p_value_low = stats.wilcoxon(population_1, population_2_low, alternative="greater")[1]
 
     test_up = p_value_up < critical_quantile

--- a/giskard/ml_worker/testing/stat_utils.py
+++ b/giskard/ml_worker/testing/stat_utils.py
@@ -18,12 +18,9 @@ def paired_t_test(population_1, population_2, alternative, critical_quantile):
     if np.array_equal(population_1, population_2):
         p_value = 1.
     else:
-        stat, p_value = stats.ttest_rel(population_1, population_2, alternative=alternative)
+        _, p_value = stats.ttest_rel(population_1, population_2, alternative=alternative)
 
-    if p_value > critical_quantile:
-        return False, p_value
-    else:
-        return True, p_value
+    return p_value <= critical_quantile, p_value
 
 def equivalence_t_test(population_1, population_2, window_size, critical_quantile):
     """
@@ -79,12 +76,9 @@ def paired_wilcoxon(population_1, population_2, alternative, critical_quantile):
     if np.array_equal(population_1, population_2):
         p_value = 1.
     else:
-        stat, p_value = stats.wilcoxon(population_1, population_2, alternative=alternative)
+        _, p_value = stats.wilcoxon(population_1, population_2, alternative=alternative)
 
-    if p_value > critical_quantile:
-        return False, p_value
-    else:
-        return True, p_value
+    return p_value <= critical_quantile, p_value
 
 
 def equivalence_wilcoxon(population_1, population_2, window_size, critical_quantile):

--- a/tests/test_metamorphic_direction.py
+++ b/tests/test_metamorphic_direction.py
@@ -113,3 +113,69 @@ def test_metamorphic_increasing_exception(german_credit_test_data, german_credit
             perturbation_dict=perturbation,
             threshold=0.5,
         )
+
+def test_metamorphic_increasing_t_test(german_credit_test_data, german_credit_model):
+    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_increasing_t_test(df=german_credit_test_data,
+                                                                   model=german_credit_model,
+                                                                   perturbation_dict=perturbation,
+                                                                   critical_quantile=0.05,
+                                                                   classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert not results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_decreasing_t_test(german_credit_test_data, german_credit_model):
+    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_decreasing_t_test(df=german_credit_test_data,
+                                                                   model=german_credit_model,
+                                                                   perturbation_dict=perturbation,
+                                                                   critical_quantile=0.05,
+                                                                   classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_increasing_wilcoxon(german_credit_test_data, german_credit_model):
+    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_increasing_wilcoxon(df=german_credit_test_data,
+                                                                     model=german_credit_model,
+                                                                     perturbation_dict=perturbation,
+                                                                     critical_quantile=0.05,
+                                                                     classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert not results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_decreasing_wilcoxon(german_credit_test_data, german_credit_model):
+    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_decreasing_wilcoxon(df=german_credit_test_data,
+                                                                     model=german_credit_model,
+                                                                     perturbation_dict=perturbation,
+                                                                     critical_quantile=0.05,
+                                                                     classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_increasing_t_test_nopert(german_credit_test_data, german_credit_model):
+    perturbation = {}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_increasing_t_test(df=german_credit_test_data,
+                                                                   model=german_credit_model,
+                                                                   perturbation_dict=perturbation,
+                                                                   critical_quantile=0.05,
+                                                                   classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert not results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_decreasing_t_test_nopert(german_credit_test_data, german_credit_model):
+    perturbation = {}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_decreasing_t_test(df=german_credit_test_data,
+                                                                   model=german_credit_model,
+                                                                   perturbation_dict=perturbation,
+                                                                   critical_quantile=0.05,
+                                                                   classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert not results.passed, f"metric = {results.metric}"

--- a/tests/test_metamorphic_direction.py
+++ b/tests/test_metamorphic_direction.py
@@ -179,3 +179,25 @@ def test_metamorphic_decreasing_t_test_nopert(german_credit_test_data, german_cr
                                                                    classification_label="Default")
     assert results.actual_slices_size[0] == len(german_credit_test_data)
     assert not results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_increasing_wilcoxon_nopert(german_credit_test_data, german_credit_model):
+    perturbation = {}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_increasing_wilcoxon(df=german_credit_test_data,
+                                                                     model=german_credit_model,
+                                                                     perturbation_dict=perturbation,
+                                                                     critical_quantile=0.05,
+                                                                     classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert not results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_decreasing_wilcoxon_nopert(german_credit_test_data, german_credit_model):
+    perturbation = {}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_decreasing_wilcoxon(df=german_credit_test_data,
+                                                                     model=german_credit_model,
+                                                                     perturbation_dict=perturbation,
+                                                                     critical_quantile=0.05,
+                                                                     classification_label="Default")
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert not results.passed, f"metric = {results.metric}"

--- a/tests/test_metamorphic_invariance.py
+++ b/tests/test_metamorphic_invariance.py
@@ -163,3 +163,14 @@ def test_metamorphic_invariance_wilcoxon(german_credit_test_data, german_credit_
 
     assert results.actual_slices_size[0] == len(german_credit_test_data)
     assert results.passed, f"metric = {results.metric}"
+
+def test_metamorphic_invariance_wilcoxon_nopert(german_credit_test_data, german_credit_model):
+    perturbation = {}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_invariance_wilcoxon(df=german_credit_test_data,
+                                                                     model=german_credit_model,
+                                                                     perturbation_dict=perturbation,
+                                                                     window_size=0.2, critical_quantile=0.05)
+
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert results.passed, f"metric = {results.metric}"

--- a/tests/test_metamorphic_invariance.py
+++ b/tests/test_metamorphic_invariance.py
@@ -142,6 +142,17 @@ def test_metamorphic_invariance_t_test(german_credit_test_data, german_credit_mo
     assert results.actual_slices_size[0] == len(german_credit_test_data)
     assert results.passed, f"metric = {results.metric}"
 
+def test_metamorphic_invariance_t_test_nopert(german_credit_test_data, german_credit_model):
+    perturbation = {}
+    tests = GiskardTestFunctions()
+    results = tests.metamorphic.test_metamorphic_invariance_t_test(df=german_credit_test_data,
+                                                                   model=german_credit_model,
+                                                                   perturbation_dict=perturbation,
+                                                                   window_size=0.2, critical_quantile=0.05)
+
+    assert results.actual_slices_size[0] == len(german_credit_test_data)
+    assert results.passed, f"metric = {results.metric}"
+
 def test_metamorphic_invariance_wilcoxon(german_credit_test_data, german_credit_model):
     perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
     tests = GiskardTestFunctions()

--- a/tests/test_metamorphic_invariance.py
+++ b/tests/test_metamorphic_invariance.py
@@ -119,7 +119,6 @@ def test_metamorphic_compare_t_test(loc_pop, scale_pop, loc_perturb, scale_pertu
 def test_metamorphic_compare_wilcoxon(loc_pop, scale_pop, loc_perturb, scale_perturb, direction, window_size, critical_quantile):
     population = np.random.normal(loc_pop, scale_pop, size=100)
     perturbation = np.random.normal(loc_perturb, scale_perturb, size=100)
-    print(perturbation)
 
     result_inc, p_value_inc = paired_wilcoxon(population, population+perturbation, alternative="less", critical_quantile=critical_quantile)
     result_dec, p_value_dec = paired_wilcoxon(population, population+perturbation, alternative="greater", critical_quantile=critical_quantile)
@@ -141,32 +140,7 @@ def test_metamorphic_invariance_t_test(german_credit_test_data, german_credit_mo
                                                          window_size=0.2, critical_quantile=0.05)
 
     assert results.actual_slices_size[0] == len(german_credit_test_data)
-    assert round(results.metric, 2) == 0.
-    return results.passed
-
-def test_metamorphic_increasing_t_test(german_credit_test_data, german_credit_model):
-    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
-    tests = GiskardTestFunctions()
-    results = tests.metamorphic.test_metamorphic_increasing_t_test(df=german_credit_test_data,
-                                                                   model=german_credit_model,
-                                                                   perturbation_dict=perturbation,
-                                                                   critical_quantile=0.05,
-                                                                   classification_label="Default")
-    assert results.actual_slices_size[0] == len(german_credit_test_data)
-    assert round(results.metric, 2) == 1.0
-    return results.passed
-
-def test_metamorphic_decreasing_t_test(german_credit_test_data, german_credit_model):
-    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
-    tests = GiskardTestFunctions()
-    results = tests.metamorphic.test_metamorphic_decreasing_t_test(df=german_credit_test_data,
-                                                                   model=german_credit_model,
-                                                                   perturbation_dict=perturbation,
-                                                                   critical_quantile=0.05,
-                                                                   classification_label="Default")
-    assert results.actual_slices_size[0] == len(german_credit_test_data)
-    assert round(results.metric, 2) == 0.0
-    return results.passed
+    assert results.passed, f"metric = {results.metric}"
 
 def test_metamorphic_invariance_wilcoxon(german_credit_test_data, german_credit_model):
     perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
@@ -177,29 +151,4 @@ def test_metamorphic_invariance_wilcoxon(german_credit_test_data, german_credit_
                                                                    window_size=0.2, critical_quantile=0.05)
 
     assert results.actual_slices_size[0] == len(german_credit_test_data)
-    assert round(results.metric, 2) == 0.
-    return results.passed
-
-def test_metamorphic_increasing_wilcoxon(german_credit_test_data, german_credit_model):
-    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
-    tests = GiskardTestFunctions()
-    results = tests.metamorphic.test_metamorphic_increasing_wilcoxon(df=german_credit_test_data,
-                                                                   model=german_credit_model,
-                                                                   perturbation_dict=perturbation,
-                                                                   critical_quantile=0.05,
-                                                                   classification_label="Default")
-    assert results.actual_slices_size[0] == len(german_credit_test_data)
-    assert round(results.metric, 2) == 1.0
-    return results.passed
-
-def test_metamorphic_decreasing_wilcoxon(german_credit_test_data, german_credit_model):
-    perturbation = {"sex": lambda x: "female" if x.sex == "male" else "male"}
-    tests = GiskardTestFunctions()
-    results = tests.metamorphic.test_metamorphic_decreasing_wilcoxon(df=german_credit_test_data,
-                                                                   model=german_credit_model,
-                                                                   perturbation_dict=perturbation,
-                                                                   critical_quantile=0.05,
-                                                                   classification_label="Default")
-    assert results.actual_slices_size[0] == len(german_credit_test_data)
-    assert round(results.metric, 2) == 0.0
-    return results.passed
+    assert results.passed, f"metric = {results.metric}"

--- a/tests/test_statistical.py
+++ b/tests/test_statistical.py
@@ -109,7 +109,6 @@ def test_disparate_impact(german_credit_data, german_credit_model):
         protected_slice=lambda df: df[df.sex == "female"],
         unprotected_slice=lambda df: df[df.sex == "male"],
         model=german_credit_model,
-        positive_outcome="Default",
-        threshold=0.8
+        positive_outcome="Not default"
     )
     assert results.passed


### PR DESCRIPTION
`stats.wilcoxon(population_1, population_2, alternative=alternative)` was failing when `population_1==population_2`. I added an if statement to avoid this issue.